### PR TITLE
Refactor: methodadd methodgen amplifiers FIX #844 (#846)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,22 +179,25 @@ Usage: java -jar target/dspot-<version>-jar-with-dependencies.jar
         properties) of the target project (e.g. ./foo.properties).
 
   [(-a|--amplifiers) Amplifier1:Amplifier2:...:AmplifierN ]
-        [optional] specify the list of amplifiers to use. By default, DSpot does
-        not use any amplifiers (None) and applies only assertion amplification.
-        Possible values are: 
-        		 - MethodAdd
-        		 - MethodRemove
-        		 - FastLiteralAmplifier
-        		 - MethodGeneratorAmplifier
-        		 - ReturnValueAmplifier
-        		 - StringLiteralAmplifier
-        		 - NumberLiteralAmplifier
-        		 - BooleanLiteralAmplifier
-        		 - CharLiteralAmplifier
-        		 - AllLiteralAmplifiers
-        		 - NullifierAmplifier
-        		 - None
-        (default: None)
+          [optional] specify the list of amplifiers to use. By default, DSpot does
+          not use any amplifiers (None) and applies only assertion amplification.
+          Possible values are: 
+          		 - MethodAdd
+          		 - MethodDuplicationAmplifier
+          		 - MethodRemove
+          		 - FastLiteralAmplifier
+          		 - TestDataMutator
+          		 - MethodGeneratorAmplifier
+          		 - MethodAdderOnExistingObjectsAmplifier
+          		 - ReturnValueAmplifier
+          		 - StringLiteralAmplifier
+          		 - NumberLiteralAmplifier
+          		 - BooleanLiteralAmplifier
+          		 - CharLiteralAmplifier
+          		 - AllLiteralAmplifiers
+          		 - NullifierAmplifier
+          		 - None
+          (default: None)
 
   [(-i|--iteration) <iteration>]
         [optional] specify the number of amplification iterations. A larger

--- a/dspot-maven/src/main/java/eu/stamp_project/DSpotMojo.java
+++ b/dspot-maven/src/main/java/eu/stamp_project/DSpotMojo.java
@@ -36,9 +36,11 @@ public class DSpotMojo extends AbstractMojo {
      *	[optional] specify the list of amplifiers to use. By default, DSpot does not use any amplifiers (None) and applies only assertion amplification.
      *	Possible values are:
      *			 - MethodAdd
+     *			 - MethodDuplicationAmplifier
      *			 - MethodRemove
      *			 - FastLiteralAmplifier
-     *			 - MethodGeneratorAmplifier
+     *			 - TestDataMutator
+     *			 - MethodAdderOnExistingObjectsAmplifier
      *			 - ReturnValueAmplifier
      *			 - StringLiteralAmplifier
      *			 - NumberLiteralAmplifier

--- a/dspot/src/main/java/eu/stamp_project/dspot/amplifier/MethodAdderOnExistingObjectsAmplifier.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/amplifier/MethodAdderOnExistingObjectsAmplifier.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
  * on 19/07/18
  */
 @SuppressWarnings("unchecked")
-public class MethodGeneratorAmplifier implements Amplifier {
+public class MethodAdderOnExistingObjectsAmplifier implements Amplifier {
 
     @Override
     public Stream<CtMethod<?>> amplify(CtMethod<?> testMethod, int iteration) {

--- a/dspot/src/main/java/eu/stamp_project/dspot/amplifier/MethodDuplicationAmplifier.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/amplifier/MethodDuplicationAmplifier.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 
-public class TestMethodCallAdder implements Amplifier {
+public class MethodDuplicationAmplifier implements Amplifier {
 
     public Stream<CtMethod<?>> amplify(CtMethod<?> method, int iteration) {
         if (method.getDeclaringType() != null) {

--- a/dspot/src/main/java/eu/stamp_project/utils/options/AmplifierEnum.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/options/AmplifierEnum.java
@@ -2,18 +2,18 @@ package eu.stamp_project.utils.options;
 
 import eu.stamp_project.dspot.amplifier.*;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public enum AmplifierEnum {
 
-    MethodAdd(new TestMethodCallAdder()),
+    MethodAdd(new MethodDuplicationAmplifier()),
+    MethodDuplicationAmplifier(new MethodDuplicationAmplifier()),
     MethodRemove(new TestMethodCallRemover()),
     FastLiteralAmplifier(new FastLiteralAmplifier()),
     TestDataMutator(new FastLiteralAmplifier()),
-    MethodGeneratorAmplifier(new MethodGeneratorAmplifier()),
+    MethodGeneratorAmplifier(new MethodAdderOnExistingObjectsAmplifier()),
+    MethodAdderOnExistingObjectsAmplifier(new MethodAdderOnExistingObjectsAmplifier()),
     ReturnValueAmplifier(new ReturnValueAmplifier()),
     StringLiteralAmplifier(new StringLiteralAmplifier()),
     NumberLiteralAmplifier(new NumberLiteralAmplifier()),
@@ -26,14 +26,22 @@ public enum AmplifierEnum {
 
     public final Amplifier amplifier;
 
+    private static final Map<String,String> deprecatedValuesToNewNames = new HashMap<>();
+
+    static {
+        deprecatedValuesToNewNames.put("MethodAdd", "MethodDuplicationAmplifier");
+        deprecatedValuesToNewNames.put("TestDataMutator", "FastLiteralAmplifier");
+        deprecatedValuesToNewNames.put("MethodGeneratorAmplifier", "MethodAdderOnExistingObjectsAmplifier");
+    }
+
     private AmplifierEnum(Amplifier amplifier) {
         this.amplifier = amplifier;
     }
 
     private static Amplifier stringToAmplifier(String amplifier) {
         try {
-            if ("TestDataMutator".equals(amplifier)) {
-                JSAPOptions.LOGGER.warn("You are using an old name for TestDataMutator.");
+            if (deprecatedValuesToNewNames.containsKey(amplifier)) {
+                JSAPOptions.LOGGER.warn("You are using an old name: " + amplifier + ".");
                 JSAPOptions.LOGGER.warn("You should use the new name: FastLiteralAmplifier.");
                 JSAPOptions.LOGGER.warn("The entry TestDataMutator will be deleted very soon.");
             }

--- a/dspot/src/test/java/eu/stamp_project/MainTest.java
+++ b/dspot/src/test/java/eu/stamp_project/MainTest.java
@@ -299,7 +299,7 @@ public class MainTest {
         Main.main(new String[]{
                 "--path-to-properties", "src/test/resources/test-projects/test-projects.properties",
                 "--test-criterion", "JacocoCoverageSelector",
-                "--amplifiers", "MethodAdd" + AmplificationHelper.PATH_SEPARATOR + "FastLiteralAmplifier" + AmplificationHelper.PATH_SEPARATOR + "MethodGeneratorAmplifier" + AmplificationHelper.PATH_SEPARATOR + "ReturnValueAmplifier",
+                "--amplifiers", "MethodAdd" + AmplificationHelper.PATH_SEPARATOR + "FastLiteralAmplifier" + AmplificationHelper.PATH_SEPARATOR + "MethodAdderOnExistingObjectsAmplifier" + AmplificationHelper.PATH_SEPARATOR + "ReturnValueAmplifier",
                 "--iteration", "1",
                 "--random-seed", "72",
                 "--test", "example.TestSuiteExample",
@@ -343,7 +343,7 @@ public class MainTest {
         Main.main(new String[]{
                 "--path-to-properties", "src/test/resources/test-projects/test-projects.properties",
                 "--test-criterion", "JacocoCoverageSelector",
-                "--amplifiers", "MethodGeneratorAmplifier" + AmplificationHelper.PATH_SEPARATOR + "ReturnValueAmplifier",
+                "--amplifiers", "MethodAdderOnExistingObjectsAmplifier" + AmplificationHelper.PATH_SEPARATOR + "ReturnValueAmplifier",
                 "--iteration", "1",
                 "--random-seed", "72",
                 "--test", "example.TestSuiteExample",
@@ -363,7 +363,7 @@ public class MainTest {
         Main.main(new String[]{
                 "--path-to-properties", "src/test/resources/test-projects/test-projects.properties",
                 "--test-criterion", "JacocoCoverageSelector",
-                "--amplifiers", "MethodGeneratorAmplifier" + AmplificationHelper.PATH_SEPARATOR + "ReturnValueAmplifier",
+                "--amplifiers", "MethodAdderOnExistingObjectsAmplifier" + AmplificationHelper.PATH_SEPARATOR + "ReturnValueAmplifier",
                 "--iteration", "1",
                 "--random-seed", "72",
                 "--test", "example.TestSuiteExample",

--- a/dspot/src/test/java/eu/stamp_project/dspot/DSpotMockedTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/DSpotMockedTest.java
@@ -1,7 +1,7 @@
 package eu.stamp_project.dspot;
 
 import eu.stamp_project.AbstractTest;
-import eu.stamp_project.dspot.amplifier.MethodGeneratorAmplifier;
+import eu.stamp_project.dspot.amplifier.MethodAdderOnExistingObjectsAmplifier;
 import eu.stamp_project.dspot.amplifier.ReturnValueAmplifier;
 import eu.stamp_project.dspot.amplifier.value.ValueCreator;
 import eu.stamp_project.dspot.selector.JacocoCoverageSelector;
@@ -42,7 +42,7 @@ public class DSpotMockedTest extends AbstractTest {
         ValueCreator.count = 0;
         RandomHelper.setSeedRandom(23L);
         final InputConfiguration configuration = InputConfiguration.get();
-        configuration.setAmplifiers(Arrays.asList(new MethodGeneratorAmplifier(), new ReturnValueAmplifier()));
+        configuration.setAmplifiers(Arrays.asList(new MethodAdderOnExistingObjectsAmplifier(), new ReturnValueAmplifier()));
         DSpot dspot = new DSpot( 1, configuration.getAmplifiers(), new JacocoCoverageSelector());
         try {
             FileUtils.cleanDirectory(new File(configuration.getOutputDirectory()));

--- a/dspot/src/test/java/eu/stamp_project/dspot/DSpotTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/DSpotTest.java
@@ -3,7 +3,7 @@ package eu.stamp_project.dspot;
 import eu.stamp_project.AbstractTest;
 import eu.stamp_project.Utils;
 import eu.stamp_project.dspot.amplifier.Amplifier;
-import eu.stamp_project.dspot.amplifier.TestMethodCallAdder;
+import eu.stamp_project.dspot.amplifier.MethodDuplicationAmplifier;
 import eu.stamp_project.dspot.selector.JacocoCoverageSelector;
 import eu.stamp_project.dspot.selector.TakeAllSelector;
 import eu.stamp_project.dspot.selector.TestSelector;
@@ -73,7 +73,7 @@ public class DSpotTest extends AbstractTest {
          */
 
         final MockDSpot dSpot = new MockDSpot(1,
-                Collections.singletonList(new TestMethodCallAdder()),
+                Collections.singletonList(new MethodDuplicationAmplifier()),
                 new JacocoCoverageSelector()
         );
         // the test class fr.inria.filter.passing.PassingTest has 3 methods, but only two are amplified

--- a/dspot/src/test/java/eu/stamp_project/dspot/amplifier/MethodAdderOnExistingObjectsAmplifierTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/amplifier/MethodAdderOnExistingObjectsAmplifierTest.java
@@ -24,19 +24,19 @@ import static org.junit.Assert.assertTrue;
  * benjamin.danglot@inria.fr
  * on 19/07/18
  */
-public class MethodGeneratorAmplifierTest extends AbstractTest {
+public class MethodAdderOnExistingObjectsAmplifierTest extends AbstractTest {
 
     @Test
     public void testInLoop() throws Exception {
 
         /*
-            Test that MethodGeneratorAmplifier amplifier is able to add statement inside a loop if this loop has not brackets
+            Test that MethodAdderOnExistingObjectsAmplifier amplifier is able to add statement inside a loop if this loop has not brackets
          */
 
         final String packageName = "fr.inria.statementadd";
         final Factory factory = Utils.getFactory();
         RandomHelper.setSeedRandom(32L);
-        MethodGeneratorAmplifier amplifier = new MethodGeneratorAmplifier();
+        MethodAdderOnExistingObjectsAmplifier amplifier = new MethodAdderOnExistingObjectsAmplifier();
         amplifier.reset(factory.Class().get(packageName + ".ClassTarget"));
 
         CtMethod<?> ctMethod = Utils.findMethod(factory.Class().get(packageName + ".TestClassTarget"), "testWithLoop");
@@ -61,13 +61,13 @@ public class MethodGeneratorAmplifierTest extends AbstractTest {
     public void testOnClassWithJavaObjects() throws Exception {
 
         /*
-            Test that the MethodGeneratorAmplifier amplifier is able to generate, and manage Collection and Map from java.util
+            Test that the MethodAdderOnExistingObjectsAmplifier amplifier is able to generate, and manage Collection and Map from java.util
          */
 
         final String packageName = "fr.inria.statementadd";
         final Factory factory = Utils.getFactory();
         RandomHelper.setSeedRandom(32L);
-        MethodGeneratorAmplifier amplifier = new MethodGeneratorAmplifier();
+        MethodAdderOnExistingObjectsAmplifier amplifier = new MethodAdderOnExistingObjectsAmplifier();
         amplifier.reset(factory.Class().get(packageName + ".ClassTarget"));
 
         CtMethod<?> ctMethod = Utils.findMethod(factory.Class().get(packageName + ".TestClassTarget"), "test");
@@ -97,7 +97,7 @@ public class MethodGeneratorAmplifierTest extends AbstractTest {
         final String packageName = "fr.inria.statementaddarray";
         final Factory factory = Utils.getFactory();
         RandomHelper.setSeedRandom(32L);
-        MethodGeneratorAmplifier amplifier = new MethodGeneratorAmplifier();
+        MethodAdderOnExistingObjectsAmplifier amplifier = new MethodAdderOnExistingObjectsAmplifier();
         amplifier.reset(factory.Class().get(packageName + ".ClassTargetAmplify"));
 
         CtMethod<?> ctMethod = Utils.findMethod(factory.Class().get(packageName + ".TestClassTargetAmplify"), "test");
@@ -128,7 +128,7 @@ public class MethodGeneratorAmplifierTest extends AbstractTest {
         CtClass<Object> ctClass = factory.Class().get("fr.inria.mutation.ClassUnderTestTest");
         RandomHelper.setSeedRandom(23L);
 
-        MethodGeneratorAmplifier amplifier = new MethodGeneratorAmplifier();
+        MethodAdderOnExistingObjectsAmplifier amplifier = new MethodAdderOnExistingObjectsAmplifier();
         amplifier.reset(ctClass);
 
         CtMethod originalMethod = Utils.findMethod(ctClass, "testLit");
@@ -166,7 +166,7 @@ public class MethodGeneratorAmplifierTest extends AbstractTest {
         final String packageName = "fr.inria.statementadd";
         final Factory factory = Utils.getFactory();
         RandomHelper.setSeedRandom(42L);
-        MethodGeneratorAmplifier amplifier = new MethodGeneratorAmplifier();
+        MethodAdderOnExistingObjectsAmplifier amplifier = new MethodAdderOnExistingObjectsAmplifier();
         amplifier.reset(factory.Class().get(packageName + ".TestClassTargetAmplify"));
 
         CtMethod<?> ctMethod = Utils.findMethod(factory.Class().get(packageName + ".TestClassTargetAmplify"), "test");

--- a/dspot/src/test/java/eu/stamp_project/dspot/amplifier/TestMethodCallAdder.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/amplifier/TestMethodCallAdder.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
  * benjamin.danglot@inria.fr
  * on 12/7/16
  */
-public class TestMethodCallAdderTest extends AbstractTest {
+public class TestMethodCallAdder extends AbstractTest {
 
     @Test
     public void testMethodCallAddOnInvocationWithCast() {
@@ -30,7 +30,7 @@ public class TestMethodCallAdderTest extends AbstractTest {
 
         CtClass<Object> testClass = Utils.getFactory().Class().get("fr.inria.mutation.ClassUnderTestTest");
 
-        TestMethodCallAdder methodCallAdder = new TestMethodCallAdder();
+        MethodDuplicationAmplifier methodCallAdder = new MethodDuplicationAmplifier();
         methodCallAdder.reset(testClass);
 
         final CtMethod<?> originalMethod = testClass.getMethods().stream().filter(m -> "testWithCast".equals(m.getSimpleName())).findFirst().get();
@@ -48,7 +48,7 @@ public class TestMethodCallAdderTest extends AbstractTest {
 
         CtClass<Object> testClass = Utils.getFactory().Class().get("fr.inria.mutation.ClassUnderTestTest");
 
-        TestMethodCallAdder methodCallAdder = new TestMethodCallAdder();
+        MethodDuplicationAmplifier methodCallAdder = new MethodDuplicationAmplifier();
         methodCallAdder.reset(testClass);
 
         final CtMethod<?> originalMethod = testClass.getMethods().stream().filter(m -> "testAddCall".equals(m.getSimpleName())).findFirst().get();
@@ -70,7 +70,7 @@ public class TestMethodCallAdderTest extends AbstractTest {
     @Test
     public void testAddInIf() throws Exception {
         CtClass<Object> testClass = Utils.getFactory().Class().get("fr.inria.mutation.ClassUnderTestTest");
-        TestMethodCallAdder methodCallAdder = new TestMethodCallAdder();
+        MethodDuplicationAmplifier methodCallAdder = new MethodDuplicationAmplifier();
         methodCallAdder.reset(testClass);
         final CtMethod<?> originalMethod = Utils.findMethod(testClass, "testWithIf");
         final Stream<CtMethod<?>> amplify = methodCallAdder.amplify(originalMethod, 0);

--- a/dspot/src/test/java/eu/stamp_project/dspot/assertgenerator/AssertGeneratorHelperTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/assertgenerator/AssertGeneratorHelperTest.java
@@ -2,7 +2,7 @@ package eu.stamp_project.dspot.assertgenerator;
 
 import eu.stamp_project.AbstractTest;
 import eu.stamp_project.Utils;
-import eu.stamp_project.dspot.amplifier.MethodGeneratorAmplifier;
+import eu.stamp_project.dspot.amplifier.MethodAdderOnExistingObjectsAmplifier;
 import eu.stamp_project.test_framework.TestFramework;
 import eu.stamp_project.utils.AmplificationHelper;
 import eu.stamp_project.utils.program.InputConfiguration;
@@ -210,7 +210,7 @@ public class AssertGeneratorHelperTest extends AbstractTest {
 
         final String packageName = "fr.inria.statementaddarray";
         final Factory factory = Utils.getFactory();
-        MethodGeneratorAmplifier amplifier = new MethodGeneratorAmplifier();
+        MethodAdderOnExistingObjectsAmplifier amplifier = new MethodAdderOnExistingObjectsAmplifier();
         amplifier.reset(factory.Class().get(packageName + ".ClassTargetAmplify"));
 
         CtMethod<?> ctMethod = Utils.findMethod(factory.Class().get(packageName + ".TestClassTargetAmplify"), "test");

--- a/dspot/src/test/java/eu/stamp_project/dspot/budget/SimpleBudgetizerTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/budget/SimpleBudgetizerTest.java
@@ -3,12 +3,11 @@ package eu.stamp_project.dspot.budget;
 import eu.stamp_project.AbstractTest;
 import eu.stamp_project.Utils;
 import eu.stamp_project.dspot.amplifier.IterationDecoratorAmplifier;
-import eu.stamp_project.dspot.amplifier.MethodGeneratorAmplifier;
+import eu.stamp_project.dspot.amplifier.MethodAdderOnExistingObjectsAmplifier;
 import eu.stamp_project.dspot.amplifier.NumberLiteralAmplifier;
 import eu.stamp_project.dspot.amplifier.ReturnValueAmplifier;
 import eu.stamp_project.test_framework.TestFramework;
 import eu.stamp_project.utils.program.InputConfiguration;
-import eu.stamp_project.utils.AmplificationHelper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +34,7 @@ public class SimpleBudgetizerTest extends AbstractTest {
         InputConfiguration.get().setAmplifiers(
                 Arrays.asList(
                         new IterationDecoratorAmplifier(new ReturnValueAmplifier(), 3),
-                        new IterationDecoratorAmplifier(new MethodGeneratorAmplifier(), 2),
+                        new IterationDecoratorAmplifier(new MethodAdderOnExistingObjectsAmplifier(), 2),
                         new NumberLiteralAmplifier()
                 )
         );


### PR DESCRIPTION
* refactor: rename MethodAdd to MethodDuplicationAmplifier and MethodGenerator to MethodAdderOnExistingObjectsAmplifier

* doc: update documentation with new values